### PR TITLE
# Release 0.77.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "telegram_bots_api"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "async-trait",
  "cargo-minimal-versions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 name = "telegram_bots_api"
 edition = "2021"
 rust-version = "1.74.0"
-version = "0.76.0"
+version = "0.77.0"
 license = "MIT"
 description = "Telegram bots api simple rust wrapper, and no more."
 documentation = "https://docs.rs/telegram_bots_api"
@@ -14,7 +14,7 @@ keywords = ["telegram", "bots", "api"]
 authors = ["Marat Khusnetdinov <khusnetdinov@gmail.com>"]
 
 [package.metadata]
-talegram-version = "7.6"
+talegram-version = "7.7"
 
 [features]
 nightly = []

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Static Badge](https://img.shields.io/badge/Project_Status-development-red)
 [![codecov](https://codecov.io/gh/khusnetdinov/telegram_bots_api/graph/badge.svg?token=HODA8WDALK)](https://codecov.io/gh/khusnetdinov/telegram_bots_api)
 [![crates.io](https://img.shields.io/crates/v/telegram_bots_api.svg)](https://crates.io/crates/telegram_bots_api)
-![Static Badge](https://img.shields.io/badge/Telegram_Bot_API-7.6-green)
+![Static Badge](https://img.shields.io/badge/Telegram_Bot_API-7.7-green)
 [![docs.rs](https://img.shields.io/docsrs/telegram_bots_api)](https://docs.rs/telegram_bots_api/latest/telegram_bots_api/)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkhusnetdinov%2Ftelegram.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkhusnetdinov%2Ftelegram?ref=badge_shield)
 
@@ -27,7 +27,7 @@ Run `cargo add telegram_bots_api`, or add lines to `Cargo.toml`:
 
 ```toml
 [dependencies]
-telegram_bots_api = "0.76.0"
+telegram_bots_api = "0.77.0"
 rust-version = "1.74.0"
 ```
 

--- a/src/api/structs.rs
+++ b/src/api/structs.rs
@@ -194,6 +194,7 @@ pub mod paid_media_info;
 pub mod paid_media_photo;
 pub mod paid_media_preview;
 pub mod paid_media_video;
+pub mod refunded_payment;
 pub mod revenue_withdrawal_state_failed;
 pub mod revenue_withdrawal_state_pending;
 pub mod revenue_withdrawal_state_succeeded;

--- a/src/api/structs/message.rs
+++ b/src/api/structs/message.rs
@@ -33,6 +33,7 @@ use crate::api::structs::passport_data::PassportData;
 use crate::api::structs::photo_size::PhotoSize;
 use crate::api::structs::poll::Poll;
 use crate::api::structs::proximity_alert_triggered::ProximityAlertTriggered;
+use crate::api::structs::refunded_payment::RefundedPayment;
 use crate::api::structs::sticker::Sticker;
 use crate::api::structs::story::Story;
 use crate::api::structs::successful_payment::SuccessfulPayment;
@@ -221,4 +222,6 @@ pub struct Message {
     pub chat_background_set: Option<ChatBackground>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paid_media: Option<PaidMediaInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refunded_payment: Option<RefundedPayment>,
 }

--- a/src/api/structs/refunded_payment.rs
+++ b/src/api/structs/refunded_payment.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+/// <https://core.telegram.org/bots/api#refundedpayment>
+/// This object contains basic information about a refunded payment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RefundedPayment {
+    pub currency: String,
+    pub total_amount: i64,
+    pub invoice_payload: String,
+    pub telegram_payment_charge_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_payment_charge_id: Option<String>,
+}


### PR DESCRIPTION
Bot API 7.7: https://core.telegram.org/bots/api#july-7-2024

- [x] Added the class [RefundedPayment](https://core.telegram.org/bots/api#refundedpayment), containing information - about a refunded payment.
- [x] Added the field refunded_payment to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about a refunded payment.
- [x] Added the field isVerticalSwipesEnabled and the methods enableVerticalSwipes, disableVerticalSwipes to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [x] Added the [event](https://core.telegram.org/bots/webapps#events-available-for-mini-apps) scanQrPopupClosed for Mini Apps.